### PR TITLE
Normalize line endings to LF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,50 @@
+# .gitattributes snippet to force users to use same line endings for project.
+#
+# Handle line endings automatically for files detected as text
+# and leave all files detected as binary untouched.
+* text=auto
+
+#
+# The above will handle all files NOT found below
+# https://help.github.com/articles/dealing-with-line-endings/
+# https://github.com/Danimoth/gitattributes/blob/master/Web.gitattributes
+
+
+
+# These files are text and should be normalized (Convert crlf => lf)
+*.php text
+*.css text
+*.js text
+*.json text
+*.htm text
+*.html text
+*.xml text
+*.txt text
+*.ini text
+*.inc text
+*.pl text
+*.rb text
+*.py text
+*.scm text
+*.sql text
+.htaccess text
+*.sh text
+
+# These files are binary and should be left untouched
+# (binary is a macro for -text -diff)
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.mov binary
+*.mp4 binary
+*.mp3 binary
+*.flv binary
+*.fla binary
+*.swf binary
+*.gz binary
+*.zip binary
+*.7z binary
+*.ttf binary
+*.pyc binary


### PR DESCRIPTION
 Saw the .gitignore updated on 0cf6428, this further normalizes the repo for cross workspace use. LF line endings are UNIX specific. Enabling the inter-use of WIndows + UNIX operating systems.

The .gitattributes template [came from this gist](https://gist.github.com/ajdruff/16427061a41ca8c08c05992a6c74f59e).